### PR TITLE
Add cursor-pointer to collapsible section triggers

### DIFF
--- a/components/bank-country-section.tsx
+++ b/components/bank-country-section.tsx
@@ -39,7 +39,7 @@ export function BankCountrySection({
   return (
     <>
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger className="flex w-full items-center justify-between rounded-lg bg-secondary/50 px-4 py-3 hover:bg-secondary transition-colors">
+        <CollapsibleTrigger className="flex w-full cursor-pointer items-center justify-between rounded-lg bg-secondary/50 px-4 py-3 hover:bg-secondary transition-colors">
           <div className="flex items-center gap-3">
             <CountryFlag countryCode={countryCode} size="md" />
             <div className="text-start">

--- a/components/merchant-category-section.tsx
+++ b/components/merchant-category-section.tsx
@@ -35,7 +35,7 @@ export function MerchantCategorySection({
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger className="flex w-full items-center justify-between rounded-lg bg-secondary/50 px-4 py-3 hover:bg-secondary transition-colors">
+      <CollapsibleTrigger className="flex w-full cursor-pointer items-center justify-between rounded-lg bg-secondary/50 px-4 py-3 hover:bg-secondary transition-colors">
         <div className="flex items-center gap-3">
           <span className="text-2xl" role="img" aria-label={category?.label}>
             {category?.emoji}


### PR DESCRIPTION
## Summary
- Adds `cursor-pointer` to `CollapsibleTrigger` in `BankCountrySection` and `MerchantCategorySection`
- Tailwind's Preflight reset sets `cursor: default` on buttons, which overrides the browser's native pointer cursor — making the expandable panels appear non-clickable to users

## Test plan
- [ ] Hover over a country section header on the Banks tab — cursor should now show as pointer
- [ ] Hover over a category section header on the Merchants tab — cursor should now show as pointer

🤖 Generated with [Claude Code](https://claude.com/claude-code)