### PR TITLE
Fix: Change filter dropdown trigger to "click" to prevent scroll lock

### DIFF
--- a/components/filter-bar.tsx
+++ b/components/filter-bar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Search, Filter, X, Flag, Info } from "lucide-react";
 import {
@@ -43,6 +44,8 @@ export function FilterBar({
   onCountryChange,
   activeView,
 }: FilterBarProps) {
+  const [filterOpen, setFilterOpen] = useState(false);
+
   const toggleSupportStatus = (status: BaseSupportStatus) => {
     if (selectedStatuses.includes(status)) {
       onStatusChange(selectedStatuses.filter((s) => s !== status));
@@ -89,9 +92,13 @@ export function FilterBar({
         )}
       </InputGroup>
 
-      <DropdownMenu>
+      <DropdownMenu open={filterOpen} onOpenChange={setFilterOpen}>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline">
+          <Button
+            variant="outline"
+            onPointerDown={(event) => event.preventDefault()}
+            onClick={() => setFilterOpen((open) => !open)}
+          >
             <Filter size={16} />
             Filter
             {selectedStatuses.length + selectedCountries.length > 0 && (
@@ -101,7 +108,10 @@ export function FilterBar({
             )}
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-48" align="end">
+        <DropdownMenuContent
+          className="w-48"
+          align="end"
+        >
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
               <Info />


### PR DESCRIPTION
Previously, the filter dropdown opened on pointerdown. (Dragging on the filter button will open the dropdown menu **instead** of tapping on it / clicking it and **releasing the mouse button). This caused two issues:

## Issues caused:

1. Mobile Scroll Lock: Initiating a scroll with the finger starting on the filter button opened the filter menu. If the user continued scrolling until the filter button and dropdown was out of view, the background scroll lock still remained active due to the still-open dropdown menu.

2. User is unable to "cancel" their click by holding down the mouse button and dragging the cursor outside the button before releasing the mouse button again.

## Proposed fix:

Now, "dragging" / swiping over the filter button, as well as pressing the mouse button won't open the filter dropdown unless the mouse button is released while still hovering over the button area (=> onClick). This aligns better with what the user expects when clicking on a button.

## Example of wrong behaviour:

- This shows the mobile version. When I start scrolling and position my finger on the filter button while doing so, I can scroll, while also opening the filter dropdown. Once the scrolling motion stops, I cannot scroll any further until i "exit" the filter dropdown by tapping somewhere else
- Note the Filter dropdown disappearing towards the top in the example attached below

<img width="240" height="426" alt="demo" src="https://github.com/user-attachments/assets/4c3c4674-f982-4506-88b3-8958b093c03f" />
